### PR TITLE
Hierarchical queries and sub-queries

### DIFF
--- a/lib/GraphQLServer.ts
+++ b/lib/GraphQLServer.ts
@@ -1,19 +1,17 @@
 import { BigIntResolver } from "graphql-scalars"
 import { GraphQLServer as BaseGraphQLServer } from "graphql-yoga"
-import { ResolverCallbackRecord } from "./QueryResolver"
+import { IResolverCallbackRecord } from "./QueryResolver"
 
 export interface IGraphQLServerConfigurer {
     SDL: string
-    resolvers: ResolverCallbackRecord
+    resolvers: IResolverCallbackRecord
 }
 
 export class GraphQLServer extends BaseGraphQLServer {
     constructor(config: IGraphQLServerConfigurer) {
         const typeDefs = config.SDL
-        const resolvers = {
-            BigInt: BigIntResolver,
-            Query: config.resolvers,
-        }
+        const resolvers = config.resolvers as any
+        resolvers.BigInt = BigIntResolver
 
         super({ typeDefs, resolvers })
     }

--- a/lib/GraphQLServerMetadataConfig.ts
+++ b/lib/GraphQLServerMetadataConfig.ts
@@ -4,24 +4,24 @@ import { StorageFunctionMetadata as StorageFunctionMetadataV3 } from "@polkadot/
 import { stringLowerFirst } from "@polkadot/util"
 import { IGraphQLServerConfigurer } from "./GraphQLServer"
 import { ModuleDescriptor, ModuleDescriptorIndex } from "./ModuleDescriptor"
-import { ResolverCallbackRecord } from "./QueryResolver"
+import { IResolverCallbackRecord } from "./QueryResolver"
 import { SDLSchema } from "./SDLSchema"
 import { StorageDescriptor, StorageType } from "./StorageDescriptor"
 import { MustStringCodec } from "./util"
-import { ResolverIndex } from "./WASMInstance"
+import { IResolverIndex } from "./WASMInstance"
 
 interface ITypeClassifier {
-    queryBlockSDL(schema: SDLSchema, resolvers: ResolverIndex, modules: ModuleDescriptorIndex): void
+    queryBlockSDL(schema: SDLSchema, resolvers: IResolverIndex, modules: ModuleDescriptorIndex): void
     moduleBlocksSDL(schema: SDLSchema, modules: ModuleDescriptorIndex): void
 }
 
 interface IQueryResolver {
-    moduleResolvers(resolvers: ResolverCallbackRecord, modules: ModuleDescriptorIndex): void
-    wasmResolvers(resolvers: ResolverCallbackRecord, runtimeResolvers: ResolverIndex): void
+    moduleResolvers(resolvers: IResolverCallbackRecord, modules: ModuleDescriptorIndex): void
+    wasmResolvers(resolvers: IResolverCallbackRecord, runtimeResolvers: IResolverIndex): void
 }
 
 interface IResolverSource {
-    resolvers(): ResolverIndex
+    resolvers(): IResolverIndex
 }
 
 export class GraphQLServerMetadataConfig
@@ -116,8 +116,8 @@ export class GraphQLServerMetadataConfig
         return schema.SDL
     }
 
-    public get resolvers(): ResolverCallbackRecord {
-        const resolvers: ResolverCallbackRecord = {}
+    public get resolvers(): IResolverCallbackRecord {
+        const resolvers: IResolverCallbackRecord = {}
         this.queryResolver.moduleResolvers(resolvers, this.modules)
         this.queryResolver.wasmResolvers(resolvers, this.queryRuntime.resolvers())
         return resolvers

--- a/lib/ResolverExecutionContext.ts
+++ b/lib/ResolverExecutionContext.ts
@@ -12,8 +12,8 @@ export class ResolverExecutionContext {
     protected referenceStack: any = [this.response]
     protected pointers = new Array<pointer<any>>()
 
-    constructor(parent: WASMInstance, 
-                ptr: pointer<ResolverExecutionContext>, 
+    constructor(parent: WASMInstance,
+                ptr: pointer<ResolverExecutionContext>,
                 execResolve: PromiseResolver) {
         this.parent = parent
         this.contexPtr = ptr

--- a/lib/ResolverExecutionContext.ts
+++ b/lib/ResolverExecutionContext.ts
@@ -15,9 +15,9 @@ export class ResolverExecutionContext {
     constructor(parent: WASMInstance,
                 ptr: pointer<ResolverExecutionContext>,
                 execResolve: PromiseResolver) {
-        this.parent = parent
-        this.contexPtr = ptr
-        this.resolveFunc = execResolve
+				this.parent = parent
+				this.contexPtr = ptr
+				this.resolveFunc = execResolve
     }
 
     public toPointer(): pointer<ResolverExecutionContext> {
@@ -70,13 +70,19 @@ export class ResolverExecutionContext {
     }
 
     public increaseExecDepth(depth: number = 1) {
-        this.depth += depth
-    }
+		this.depth += depth
+	}
 
-    public decreaseExecDepth(depth: number = 1) {
-        this.depth -= depth
-        if (this.depth === 0) {
-            this.resolveExecution()
-        }
-    }
+	public decreaseExecDepth(depth: number = 1) {
+		// This is to fix a weird AssemblyScript issue: we must wait 0
+		// milliseconds (ie, the promise resolution overhead) or the
+		// memory freed by the RessolverExecutionContext will be released
+		// too early, and the WASM function may crash.
+		new Promise( resolve => setTimeout(resolve, 0) ).then(() => {
+			this.depth -= depth
+			if (this.depth === 0) {
+				this.resolveExecution()
+			}
+		})
+	}
 }

--- a/lib/SDLSchema.ts
+++ b/lib/SDLSchema.ts
@@ -31,6 +31,10 @@ export class SDLSchema implements ISDLSchemaLineWriter {
     }
 
     public type(name: string, implementsInterface?: string): SDLTypeDef {
+        if (this.hasType(name)) {
+            return this.types.get(name) as SDLTypeDef
+        }
+
         const typeDec = new SDLTypeDef(name, implementsInterface)
         this.types.set(name, typeDec)
         return typeDec

--- a/lib/WASMInstance.ts
+++ b/lib/WASMInstance.ts
@@ -309,7 +309,6 @@ export class WASMInstance<T extends {} = {}> {
             this.dispatchApiReponse(ctx, codec, callback, callbackWrapper)
             ctx.decreaseExecDepth()
         }).catch((err) => {
-            // FIXME! Signal error
             this.logger.error(err)
             ctx.resolveExecution()
         })
@@ -325,7 +324,6 @@ export class WASMInstance<T extends {} = {}> {
             }
             ctx.decreaseExecDepth()
         }).catch((err) => {
-            // FIXME! Signal error
             this.logger.error(err)
             ctx.resolveExecution()
         })
@@ -451,7 +449,7 @@ export class WASMInstance<T extends {} = {}> {
                 this.logger.info(value)
             },
             logs: (value: pointer<string>) => {
-                this.logger.info("console.log", this.module.__getString(value)) // FIXME! Allow console.log (lint)
+                this.logger.info("console.log", this.module.__getString(value)) 
             },
         }
     }

--- a/lib/WASMInstance.ts
+++ b/lib/WASMInstance.ts
@@ -4,6 +4,7 @@ import { stringLowerFirst } from "@polkadot/util"
 import { ASUtil, instantiateBuffer } from "assemblyscript/lib/loader"
 import { ILogger } from "./Logger"
 import { ResolverExecutionContext } from "./ResolverExecutionContext"
+import { implementsTKeys } from "./util"
 
 export type pointer<T= {}> = number
 
@@ -41,12 +42,18 @@ export interface IResolver {
     filters: string[]
 }
 
-export type ResolverIndex = Record<string, IResolver>
+export function isIResolver(value: any): value is IResolver {
+    return implementsTKeys<IResolver>(value, ["returnTypeSDL", "filters"])
+}
 
-interface IResolverWrapper {}
+export interface IResolverIndex {
+    [index: string]: IResolver | IResolverIndex
+}
+
+type IResolverWrapper = any
 
 interface IResolverNamespace {
-    [index: string]: pointer<IResolverWrapper>
+    [index: string]: pointer<IResolverWrapper> | IResolverNamespace
 }
 
 export interface IResolverArgs {
@@ -72,6 +79,7 @@ interface IModuleGlue {
     ResolverType(queryPtr: pointer<IResolverWrapper>): pointer<string>
     ResolverParams(queryPtr: pointer<IResolverWrapper>): pointer<string[]>
     SetContextParams(ctxPtr: pointer<ResolverExecutionContext>, paramsPtr: pointer<ITypedMap<string, IJSONResponse>>): void
+    SetContextParent(ctxPtr: pointer<ResolverExecutionContext>, paramsPtr: pointer<ITypedMap<string, IJSONResponse>>): void
 }
 
 interface IQueryModule extends ASUtil {
@@ -100,42 +108,57 @@ export class WASMInstance<T extends {} = {}> {
         // FIXME! Assert module sanity by checking for required types
     }
 
-    public async exec(name: string, args: IResolverArgs): Promise<any> {
+    public async exec(path: string[], args: IResolverArgs, root?: any): Promise<any> {
         const parent = this
         return new Promise<any>( (resolve, reject) => {
             const ctxPointer = this.newContext()
             const ctxVirtual = new ResolverExecutionContext(
-                this, 
-                ctxPointer, 
-                resolve
+                this,
+                ctxPointer,
+                resolve,
             )
             const paramsPtr = this.argsToStringJSONMap(ctxVirtual, args)
             this.module.glue.SetContextParams(ctxPointer, paramsPtr)
-            this.executionContexts.set(ctxPointer, ctxVirtual) 
+            
+            if (typeof root !== "undefined") {
+                const parentPtr = this.argsToStringJSONMap(ctxVirtual, root)
+                this.module.glue.SetContextParent(ctxPointer, parentPtr)
+            }
 
-            this.module.glue.ResolveQuery(this.module.resolvers[name], ctxPointer)
+            this.executionContexts.set(ctxPointer, ctxVirtual)
+
+            this.module.glue.ResolveQuery(this.findResolverFromPath(path), ctxPointer)
         })
     }
 
-    public resolvers(): ResolverIndex {
-        const output: ResolverIndex = {}
+    public resolvers(input?: IResolverNamespace): IResolverIndex {
+        if (typeof input === "undefined") {
+            input = this.module.resolvers
+        }
 
-        for (const key of Object.keys(this.module.resolvers)) {
-            output[key] = {
-                returnTypeSDL: this.module.__getString(
-                    this.module.glue.ResolverType(
-                        this.module.resolvers[key],
+        const output: IResolverIndex = {}
+
+        for (const key of Object.keys(input)) {
+            // Resolvers will be Globals
+            if (input[key] instanceof WebAssembly.Global) {
+                output[key] = {
+                    returnTypeSDL: this.module.__getString(
+                        this.module.glue.ResolverType(
+                            input[key] as pointer<IResolverWrapper>,
                         ),
                     ),
-                filters: this.stringArrayFromPointer(
-                    this.module.__getArray(
-                        this.module.glue.ResolverParams(
-                            this.module.resolvers[key],
+                    filters: this.stringArrayFromPointer(
+                        this.module.__getArray(
+                            this.module.glue.ResolverParams(
+                                input[key] as pointer<IResolverWrapper>,
+                            ),
                         ),
                     ),
-                ),
+                }
+            } else {
+                const ns = this.resolvers(input[key] as IResolverNamespace)
+                output[key] = ns as IResolverIndex
             }
-
         }
 
         return output
@@ -144,6 +167,16 @@ export class WASMInstance<T extends {} = {}> {
     public deleteContext(ptr: pointer<ResolverExecutionContext>) {
         this.executionContexts.delete(ptr)
         this.module.__release(ptr)
+    }
+
+    protected findResolverFromPath(path: string[]): pointer<IResolverWrapper> {
+        let ctx: any = this.module.resolvers
+        while (path.length > 0) {
+            const fragment = path[0]
+            path.shift()
+            ctx = ctx[fragment]
+        }
+        return ctx as pointer<IResolverWrapper>
     }
 
     protected getExecutionContext(ctx: pointer<ResolverExecutionContext>): ResolverExecutionContext {
@@ -170,11 +203,10 @@ export class WASMInstance<T extends {} = {}> {
     }
 
     protected envModule(): IEnvImport {
-        const logger = this.logger
+        const parent = this
         return {
             abort(msg: any, file: any, line: any, column: any) {
-                console.log(file, msg, line, column)
-                logger.error("abort called at main.ts:" + line + ":" + column)
+                parent.logger.error(parent.module.__getString(file) + ":" + line + "/" + column, parent.module.__getString(msg))
             },
             memory: new WebAssembly.Memory({
                 initial: 256,
@@ -199,7 +231,7 @@ export class WASMInstance<T extends {} = {}> {
     protected argsToStringJSONMap(ctx: ResolverExecutionContext, args: IResolverArgs): pointer<IJSONResponse> {
         const output = this.allocateStringJSONMap(ctx)
         for (const key of Object.keys(args)) {
-            const strPtr = this.allocateString(ctx, key) 
+            const strPtr = this.allocateString(ctx, key)
             const jsonPtr = this.parseJson(ctx, args[key])
             this.module.glue.SetTypedMapEntry(output, strPtr, jsonPtr)
         }

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -21,3 +21,13 @@ export function TrimString(str: string, ch0: string, ch1: string) {
 
     return (start > 0 || end < str.length) ? str.substring(start, end) : str
 }
+
+export function implementsTKeys<T>(obj: any, keys: Array<keyof T>): obj is T {
+    if (!obj || !Array.isArray(keys)) {
+        return false
+    }
+
+    const implementKeys = keys.reduce((impl, key) => impl && key in obj, true)
+
+    return implementKeys
+}


### PR DESCRIPTION
Linked with https://github.com/Joystream/query-resolver-toolkit/pull/2, the query-resolver side of this update.

## Abstract

Allows types in the schema to resolve sub-queries. For example, A `category` in the forum has `threads` which have `posts`: it is now possible to fetch all three levels (or any number of levels) in a single query.

## In detail

The queries we've been working on have all been at the top level. That is, they're general queries that only have one level of 'depth' in terms of the data structure. 

For example, we could make separate queries for the forum categories, threads and posts:

```
query {
  forumCategories { id,  title }
  forumThreads { id, title }
  forumPosts { id, title }
}
```

There are various views of those things - for example filtering the threads by category id - but they're all distinct and separate. That reflects how they're stored in the blockchain, but it's not very useful for an API consumer because they know that these different data types are related. 

Specifically, in this case, they know that there is a hierarchy of `categories` `->` `threads` `->` `posts`. Categories contain threads (and sub-categories) and threads contain posts.

What API consumer actually wants is to get grouped data sets in single query. They might want to get all the categories and all the threads in each category, for example. In other words, this:

```
query {
  forumCategories {
    id
    title
    threads {
      id
      title
    }
  }
}
```

Which translates as _give me the title and ID of each category, and the title and ID of each thread in that category_. 

Given the flat structure we had at the beginning of the week, that wasn't possible. Not only was there no way of registering 'nested' queries (the threads inside Category above), the query resolvers weren't aware of their place in the hierarchy -- they didn't know who their parents were.

Now the resolvers do know there they sit in the hierarchy, and they can register themselves as type members at any level, resulting in schemas like:

```
type Category {
  id: BigInt
  title: String
  description: String
  deleted: Boolean
  archived: Boolean
  threads(category: Int = 0, start: Int = 1): [Thread] // <-- this is added dynamically
}

type Query {
  forumCategories(start: Int = 1): [Category]
  forumThreads(category: Int = 0, start: Int = 1): [Thread] // <-- this is the same resolver
}

type Thread {
  id: BigInt
  title: String
  category_id: BigInt
  nr_in_category: Int
}
```

which allows the query:

```
query {
  forumCategories {
    id
    title
    threads {
      id
      title
    }
  }
}
```

and the resulting output:

```
{
  "data": {
    "forumCategories": [
      {
        "id": 1,
        "title": "General Discussion",
        "threads": [
          {
            "id": 1,
            "title": "Code of Conduct"
          },
          {
            "id": 3,
            "title": "How to Start A Storage Node?"
          },
          {
            "id": 6,
            "title": "Introduction: Bedeho Mender"
          },
          {
            "id": 8,
            "title": "Improving Forum Functionality?"
          },
          {
            "id": 10,
            "title": "Joystream Unofficial Tutorial Video"
          }
        ]
      },
      {
        "id": 2,
        "title": "Joystream Roles",
        "threads": [
          {
            "id": 4,
            "title": "Content Curator"
          },
          {
            "id": 9,
            "title": "Distributor (Bandwidth Provider)"
          }
        ]
      },
      // ... etc ...
    ]
  }
}
```